### PR TITLE
simplify rclone installation and migrate to Debian Buster

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+    "files.associations": {
+        "Dockerfile.template": "dockerfile",
+    },
+}

--- a/backup/Dockerfile.template
+++ b/backup/Dockerfile.template
@@ -1,10 +1,9 @@
-FROM balenalib/%%BALENA_MACHINE_NAME%%-ubuntu:bionic
+FROM balenalib/%%BALENA_MACHINE_NAME%%-debian:buster
 
 # Install rclone
-RUN apt-get update && \
-  apt-get -y install curl man-db zip && \
-  curl https://rclone.org/install.sh | bash && \
-  rm -rf /var/lib/apt/lists/*
+RUN apt-get update \
+  && apt-get install --assume-yes --no-install-recommends rclone \
+  && rm -rf /var/lib/apt/lists/*
 
 # Configure rclone
 COPY rclone.conf /var/rclone/


### PR DESCRIPTION
migrated to Debian Buster as it had a newer version of rclone in its repository than Ubuntu Bionic (and quite a few issues were fixed between 1.35 and 1.45)